### PR TITLE
stylix: use functions in lib

### DIFF
--- a/lib/utils.nix
+++ b/lib/utils.nix
@@ -2,33 +2,28 @@
 
 {
   config.lib.stylix = {
-    # get the opacity values as strings in hexadecimal, integer and floating point values for the four opacity options
-    desktopOpacity-hex = lib.toHexString ((((builtins.ceil (config.stylix.opacity.desktop * 100)) * 255) / 100));
-    desktopOpacity-int = builtins.toString (builtins.ceil (config.stylix.opacity.desktop * 100));
-    desktopOpacity-float = builtins.toString config.stylix.opacity.desktop;
+    # get the opacity values as strings in hexadecimal, integer and floating point values
 
+    opacityToHex = opacity: lib.toHexString (
+      ((builtins.ceil (opacity * 100)) * 255 / 100)
+    );
 
-    applicationsOpacity-hex = lib.toHexString ((((builtins.ceil (config.stylix.opacity.applications * 100)) * 255) / 100));
-    applicationsOpacity-int = builtins.toString (builtins.ceil (config.stylix.opacity.applications * 100));
-    applicationsOpacity-float = builtins.toString config.stylix.opacity.applications;
+    opacityToInt = opacity: builtins.toString (
+      builtins.ceil (opacity * 100));
 
+    opacityToFloat = opacity: builtins.toString
+      opacity;
 
-    terminalOpacity-hex = lib.toHexString ((((builtins.ceil (config.stylix.opacity.terminal * 100)) * 255) / 100));
-    terminalOpacity-int = builtins.toString (builtins.ceil (config.stylix.opacity.terminal * 100));
-    terminalOpacity-float = builtins.toString config.stylix.opacity.terminal;
-
-
-    popupsOpacity-hex = lib.toHexString ((((builtins.ceil (config.stylix.opacity.popups * 100)) * 255) / 100));
-    popupsOpacity-int = builtins.toString (builtins.ceil (config.stylix.opacity.popups * 100));
-    popupsOpacity-float = builtins.toString config.stylix.opacity.popups;
-
-    backgroundPolarity =
+    polarityFrom = colors:
       let
-        red = lib.toInt config.stylix.colors.base00-rgb-r;
-        green = lib.toInt config.stylix.colors.base00-rgb-g;
-        blue = lib.toInt config.stylix.colors.base00-rgb-b;
+        red = lib.toInt colors.base00-rgb-r;
+        green = lib.toInt colors.base00-rgb-g;
+        blue = lib.toInt colors.base00-rgb-b;
       in
-      if (red + green + blue >= 150) then "light" else "dark";
+      if
+        (red + green + blue) >= 150
+      then "light"
+      else "dark";
 
     # Generate a PNG image containing a named color
 

--- a/modules/bemenu/hm.nix
+++ b/modules/bemenu/hm.nix
@@ -24,23 +24,28 @@ with config.stylix.fonts;
   };
 
   config = lib.mkIf config.stylix.targets.bemenu.enable {
-    home.sessionVariables.BEMENU_OPTS = with config.stylix.targets.bemenu; builtins.concatStringsSep " " [
-      # Inspired from https://git.sr.ht/~h4n1/base16-bemenu_opts
-      "--tb '${base01}${config.lib.stylix.popupsOpacity-hex}'"
-      "--nb '${base01}${config.lib.stylix.popupsOpacity-hex}'"
-      "--fb '${base01}${config.lib.stylix.popupsOpacity-hex}'"
-      "--hb '${base03}${config.lib.stylix.popupsOpacity-hex}'"
-      "--sb '${base03}${config.lib.stylix.popupsOpacity-hex}'"
-      "--hf '${base0A}'"
-      "--sf '${base0B}'"
-      "--tf '${base05}'"
-      "--ff '${base05}'"
-      "--nf '${base05}'"
-      "--scb '${base01}'"
-      "--scf '${base03}'"
-      "--ab '${if alternate then base00 else base01}'"
-      "--af '${if alternate then base04 else base05}'"
-      "--fn '${sansSerif.name} ${lib.optionalString (fontSize != null) (builtins.toString fontSize)}'" 
-    ];
+    home.sessionVariables.BEMENU_OPTS =
+      with config.stylix.targets.bemenu;
+      let
+        opacity = config.lib.stylix.opacityToHex config.stylix.opacity.popups;
+      in
+      builtins.concatStringsSep " " [
+        # Inspired from https://git.sr.ht/~h4n1/base16-bemenu_opts
+        "--tb '${base01}${opacity}'"
+        "--nb '${base01}${opacity}'"
+        "--fb '${base01}${opacity}'"
+        "--hb '${base03}${opacity}'"
+        "--sb '${base03}${opacity}'"
+        "--hf '${base0A}'"
+        "--sf '${base0B}'"
+        "--tf '${base05}'"
+        "--ff '${base05}'"
+        "--nf '${base05}'"
+        "--scb '${base01}'"
+        "--scf '${base03}'"
+        "--ab '${if alternate then base00 else base01}'"
+        "--af '${if alternate then base04 else base05}'"
+        "--fn '${sansSerif.name} ${lib.optionalString (fontSize != null) (builtins.toString fontSize)}'"
+      ];
   };
 }

--- a/modules/dunst/hm.nix
+++ b/modules/dunst/hm.nix
@@ -14,19 +14,22 @@ with config.stylix.fonts;
       };
 
       urgency_low = {
-        background = base01 + config.lib.stylix.popupsOpacity-hex;
+        background = base01
+          + (config.lib.stylix.opacityToHex config.stylix.opacity.popups);
         foreground = base05;
         frame_color = base0B;
       };
 
       urgency_normal = {
-        background = base01 + config.lib.stylix.popupsOpacity-hex;
+        background = base01
+          + (config.lib.stylix.opacityToHex config.stylix.opacity.popups);
         foreground = base05;
         frame_color = base0E;
       };
 
       urgency_critical = {
-        background = base01 + config.lib.stylix.popupsOpacity-hex;
+        background = base01
+          + (config.lib.stylix.opacityToHex config.stylix.opacity.popups);
         foreground = base05;
         frame_color = base08;
       };

--- a/modules/emacs/hm.nix
+++ b/modules/emacs/hm.nix
@@ -64,7 +64,9 @@ with config.stylix.fonts;
         (set-face-attribute 'default t :font "${monospace.name}" )
         ;; -----------------------------
         ;; set opacity
-        (add-to-list 'default-frame-alist '(alpha-background . ${config.lib.stylix.applicationsOpacity-int}))
+        (add-to-list 'default-frame-alist '(alpha-background . ${
+          config.lib.stylix.opacityToInt config.stylix.opacity.applications
+        }))
         ;; -----------------------------
       '';
     };

--- a/modules/gnome/hm.nix
+++ b/modules/gnome/hm.nix
@@ -46,9 +46,10 @@ in {
         document-font-name = "${serif.name}  ${toString (sizes.applications - 1)}";
         monospace-font-name = "${monospace.name} ${toString sizes.applications}";
 
-        color-scheme = if config.lib.stylix.backgroundPolarity == "dark"
-        then "prefer-dark"
-        else "default";
+        color-scheme =
+          if (config.lib.stylix.polarityFrom config.stylix.colors) == "dark"
+          then "prefer-dark"
+          else "default";
       };
       
       "org/gnome/shell/extensions/user-theme".name = "Stylix";

--- a/modules/mako/hm.nix
+++ b/modules/mako/hm.nix
@@ -9,7 +9,8 @@ with config.stylix.fonts;
   # Referenced https://github.com/stacyharper/base16-mako
   config = lib.optionalAttrs (options.services ? mako) (lib.mkIf config.stylix.targets.mako.enable {
     services.mako = {
-      backgroundColor = base00 + config.lib.stylix.popupsOpacity-hex;
+      backgroundColor = base00
+        + (config.lib.stylix.opacityToHex config.stylix.opacity.popups);
       borderColor = base0D;
       textColor = base05;
       progressColor = "over ${base02}";
@@ -17,12 +18,16 @@ with config.stylix.fonts;
       # I wish the mako hm module was like the dunst one
       extraConfig = ''
         [urgency=low]
-        background-color=${base00}${config.lib.stylix.popupsOpacity-hex}
+        background-color=${base00}${
+          config.lib.stylix.opacityToHex config.stylix.opacity.popups
+        }
         border-color=${base0D}
         text-color=${base0A}
 
         [urgency=high]
-        background-color=${base00}${config.lib.stylix.popupsOpacity-hex}
+        background-color=${base00}${
+          config.lib.stylix.opacityToHex config.stylix.opacity.popups
+        }
         border-color=${base0D}
         text-color=${base08}
       '';

--- a/modules/nixvim/nixvim.nix
+++ b/modules/nixvim/nixvim.nix
@@ -17,26 +17,28 @@
     lib.optionalAttrs (builtins.hasAttr "nixvim" options.programs) {
       programs.nixvim = {
         colorschemes.base16 = {
-          customColorScheme = let
-            colors = config.lib.stylix.colors.withHashtag;
-          in {
-            base00 = colors.base00;
-            base01 = colors.base01;
-            base02 = colors.base02;
-            base03 = colors.base03;
-            base04 = colors.base04;
-            base05 = colors.base05;
-            base06 = colors.base06;
-            base07 = colors.base07;
-            base08 = colors.base08;
-            base09 = colors.base09;
-            base0A = colors.base0A;
-            base0B = colors.base0B;
-            base0C = colors.base0C;
-            base0D = colors.base0D;
-            base0E = colors.base0E;
-            base0F = colors.base0F;
-          };
+          customColorScheme =
+            let
+              colors = config.stylix.colors.withHashtag;
+            in
+            {
+              base00 = colors.base00;
+              base01 = colors.base01;
+              base02 = colors.base02;
+              base03 = colors.base03;
+              base04 = colors.base04;
+              base05 = colors.base05;
+              base06 = colors.base06;
+              base07 = colors.base07;
+              base08 = colors.base08;
+              base09 = colors.base09;
+              base0A = colors.base0A;
+              base0B = colors.base0B;
+              base0C = colors.base0C;
+              base0D = colors.base0D;
+              base0E = colors.base0E;
+              base0F = colors.base0F;
+            };
 
           enable = true;
         };

--- a/modules/qutebrowser/hm.nix
+++ b/modules/qutebrowser/hm.nix
@@ -195,12 +195,14 @@ in {
             };
           };
         };
-        webpage = {
-          darkmode.enabled = lib.mkDefault
-            (config.lib.stylix.backgroundPolarity == "dark");
-          preferred_color_scheme = lib.mkDefault
-            config.lib.stylix.backgroundPolarity;
-        };
+        webpage =
+          let
+            polarity = config.lib.stylix.polarityFrom config.stylix.colors;
+          in
+          {
+            darkmode.enabled = lib.mkDefault (polarity == "dark");
+            preferred_color_scheme = lib.mkDefault polarity;
+          };
       };
 
       fonts = let

--- a/modules/rofi/hm.nix
+++ b/modules/rofi/hm.nix
@@ -6,17 +6,21 @@
 
   config.programs.rofi = lib.mkIf config.stylix.targets.rofi.enable {
     theme = config.stylix.colors {
-      template = with config.lib.stylix; ''
-        * {
-          background: rgba ( {{base00-rgb-r}}, {{base00-rgb-g}}, {{base00-rgb-b}}, ${popupsOpacity-int} % );
-          lightbg: rgba ( {{base01-rgb-r}}, {{base01-rgb-g}}, {{base01-rgb-b}}, ${popupsOpacity-int} % );
-          red: rgba ( {{base08-rgb-r}}, {{base08-rgb-g}}, {{base08-rgb-b}}, ${popupsOpacity-int} % );
-          blue: rgba ( {{base0D-rgb-r}}, {{base0D-rgb-g}}, {{base0D-rgb-b}}, ${popupsOpacity-int} % );
-          lightfg: rgba ( {{base06-rgb-r}}, {{base06-rgb-g}}, {{base06-rgb-b}}, ${popupsOpacity-int} % );
-          foreground: rgba ( {{base05-rgb-r}}, {{base05-rgb-g}}, {{base05-rgb-b}}, ${popupsOpacity-int} % );
-        }
-        ${builtins.readFile ./template.mustache}
-      '';
+      template =
+        let
+          opacity = config.lib.stylix.opacityToInt config.stylix.opacity.popups;
+        in
+        ''
+          * {
+            background: rgba ( {{base00-rgb-r}}, {{base00-rgb-g}}, {{base00-rgb-b}}, ${opacity} % );
+            lightbg: rgba ( {{base01-rgb-r}}, {{base01-rgb-g}}, {{base01-rgb-b}}, ${opacity} % );
+            red: rgba ( {{base08-rgb-r}}, {{base08-rgb-g}}, {{base08-rgb-b}}, ${opacity} % );
+            blue: rgba ( {{base0D-rgb-r}}, {{base0D-rgb-g}}, {{base0D-rgb-b}}, ${opacity} % );
+            lightfg: rgba ( {{base06-rgb-r}}, {{base06-rgb-g}}, {{base06-rgb-b}}, ${opacity} % );
+            foreground: rgba ( {{base05-rgb-r}}, {{base05-rgb-g}}, {{base05-rgb-b}}, ${opacity} % );
+          }
+          ${builtins.readFile ./template.mustache}
+        '';
       extension = ".rasi";
     };
 

--- a/modules/waybar/hm.nix
+++ b/modules/waybar/hm.nix
@@ -46,7 +46,9 @@ in
       }
 
       window#waybar, tooltip {
-          background: alpha(@base00, ${config.lib.stylix.desktopOpacity-float});
+          background: alpha(@base00, ${
+            config.lib.stylix.opacityToFloat config.stylix.opacity.desktop
+          });
           color: @base05;
       }
 


### PR DESCRIPTION
This PR replaces the old computed sets in `config.lib.stylix` with functions.
All occurences of the removed calls should be replaced with the function calls in the modules.

There are still a few things we could improve upon before merging this PR.
I'll commend on them once the PR is open.